### PR TITLE
revamp tutorial to spotify clone

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@reduxjs/toolkit": "^1.8.5",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",
+        "axios": "^0.27.2",
         "http-proxy-middleware": "^2.0.6",
         "msw": "^0.47.0",
         "react": "^18.2.0",
@@ -5050,6 +5051,28 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -21357,6 +21380,27 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "@reduxjs/toolkit": "^1.8.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
+    "axios": "^0.27.2",
     "http-proxy-middleware": "^2.0.6",
     "msw": "^0.47.0",
     "react": "^18.2.0",

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { store } from './store';
 import App from './App';
 
 test('show login if token is invalid', async () => {
-  render(<App />);
+  render(
+    <Provider store={store}>
+      <App />
+    </Provider>,
+  );
   const linkElement = screen.getByText(/Login with Spotify/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/client/src/components/Footer/Footer.test.tsx
+++ b/client/src/components/Footer/Footer.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { store } from '../../store';
 import Footer from './Footer';
 
 test('allow user to authenticate', async () => {
-  render(<Footer />);
-  const linkElement = screen.getByText(/Login with Spotify/i);
+  render(
+    <Provider store={store}>
+      <Footer />
+    </Provider>,
+  );
+  const linkElement = screen.getByText(/meow--fooptper/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/client/src/components/MusicPlayer/MusicPlayer.test.tsx
+++ b/client/src/components/MusicPlayer/MusicPlayer.test.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { store } from '../../store';
 import MusicPlayer from './MusicPlayer';
 
-test('allow user to authenticate', async () => {
-  render(<MusicPlayer />);
-  const linkElement = screen.getByText(/Login with Spotify/i);
+test('check that search component loads', async () => {
+  render(
+    <Provider store={store}>
+      <MusicPlayer />
+    </Provider>,
+  );
+  const linkElement = screen.getByPlaceholderText(
+    /what do you want to listen to/i,
+  );
   expect(linkElement).toBeInTheDocument();
 });

--- a/client/src/components/MusicPlayer/MusicPlayer.tsx
+++ b/client/src/components/MusicPlayer/MusicPlayer.tsx
@@ -1,4 +1,7 @@
 // this component will house the three themes: clone, my own style - emphasis on music discovery, and visualizer
+import { useEffect } from 'react';
+import { useAppDispatch } from 'src/store/hooks';
+import { setUserInfo } from 'src/store/userSlice';
 import Footer from '../Footer/Footer';
 import SpotifyTheme from '../SpotifyTheme/SpotifyTheme';
 import {
@@ -8,6 +11,24 @@ import {
 } from '../../styles/MusicPlayerStyle';
 
 function MusicPlayer() {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    const getUserInfo = async () => {
+      const response = await fetch('/auth/me');
+      const resData = await response.json();
+      const data = JSON.parse(resData);
+      if (data) {
+        const userInfo = {
+          userId: data.id,
+          userName: data.display_name,
+        };
+        dispatch(setUserInfo(userInfo));
+      }
+    };
+    getUserInfo();
+  }, [dispatch]);
+
   return (
     <MusicPlayerContainer>
       <ThemeWrapper>

--- a/client/src/components/NavBar/NavBar.test.tsx
+++ b/client/src/components/NavBar/NavBar.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { store } from '../../store';
-import Search from './NavBar';
+import NavBar from './NavBar';
 
 test('check to see if placeholder search text is in the screen', async () => {
   render(
     <Provider store={store}>
-      <Search />
+      <NavBar navBackground={false} />
     </Provider>,
   );
   const linkElement = screen.getByPlaceholderText(

--- a/client/src/components/NavBar/NavBar.test.tsx
+++ b/client/src/components/NavBar/NavBar.test.tsx
@@ -1,14 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { store } from '../../store';
-import Login from './Login';
+import Search from './NavBar';
 
-test('allow user to authenticate', async () => {
+test('check to see if placeholder search text is in the screen', async () => {
   render(
     <Provider store={store}>
-      <Login />
+      <Search />
     </Provider>,
   );
-  const linkElement = screen.getByText(/Login with Spotify/i);
+  const linkElement = screen.getByPlaceholderText(
+    /what do you want to listen to/i,
+  );
   expect(linkElement).toBeInTheDocument();
 });

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+// import { useEffect } from 'react';
 import { FaSearch } from 'react-icons/fa';
 import { CgProfile } from 'react-icons/cg';
 import useUserInfo from 'src/utils/useUserInfo';
@@ -10,12 +10,7 @@ import {
 
 function NavBar() {
   const userInfo = useUserInfo();
-  useEffect(() => {
-    if (userInfo) {
-      console.log(userInfo);
-      console.log(userInfo.userInfo.userName);
-    }
-  }, [userInfo]);
+
   return (
     <NavContainer>
       <SearchWrapper>

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { FaSearch } from 'react-icons/fa';
+import { CgProfile } from 'react-icons/cg';
+import useUserInfo from 'src/utils/useUserInfo';
+import {
+  NavContainer,
+  SearchWrapper,
+  UserWrapper,
+} from '../../styles/NavBarStyle';
+
+function NavBar() {
+  const userInfo = useUserInfo();
+  useEffect(() => {
+    if (userInfo) {
+      console.log(userInfo);
+      console.log(userInfo.userInfo.userName);
+    }
+  }, [userInfo]);
+  return (
+    <NavContainer>
+      <SearchWrapper>
+        <FaSearch />
+        <input
+          type="text"
+          placeholder="What do you want to listen to?"
+        />
+      </SearchWrapper>
+      <UserWrapper>
+        <a href="#replace_later">
+          <CgProfile />
+          <span>{userInfo.userInfo.userId}</span>
+        </a>
+      </UserWrapper>
+    </NavContainer>
+  );
+}
+
+export default NavBar;

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -7,12 +7,13 @@ import {
   SearchWrapper,
   UserWrapper,
 } from '../../styles/NavBarStyle';
+import { NavBkgdType } from '../../types';
 
-function NavBar() {
+function NavBar({ navBackground }: NavBkgdType) {
   const userInfo = useUserInfo();
 
   return (
-    <NavContainer>
+    <NavContainer navBackground={navBackground}>
       <SearchWrapper>
         <FaSearch />
         <input

--- a/client/src/components/Playlist/Playlist.test.tsx
+++ b/client/src/components/Playlist/Playlist.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { store } from '../../store';
+import Playlist from './Playlist';
+
+test('test to find unordered list in the component', async () => {
+  render(
+    <Provider store={store}>
+      <Playlist />
+    </Provider>,
+  );
+  const listEle = screen.getByRole('list');
+  expect(listEle).toBeInTheDocument();
+});

--- a/client/src/components/Playlist/Playlist.tsx
+++ b/client/src/components/Playlist/Playlist.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from 'react';
 import { useAppDispatch } from 'src/store/hooks';
 import usePlaylist from 'src/utils/usePlaylist';
-import { setPlaylist } from '../../store/musicPlayerSlice';
+import {
+  setPlaylist,
+  setSelectedPlaylist,
+} from '../../store/musicPlayerSlice';
 import { PlaylistContainer } from '../../styles/PlaylistStyle';
 import { PlaylistItemsType } from '../../types';
 
@@ -19,10 +22,15 @@ function Playlist() {
           return { name, id };
         },
       );
-      dispatch(setPlaylist(playlists));
+      if (playlists) {
+        dispatch(setPlaylist(playlists)); // set all playlists from user's playlist data
+      }
+      if (playlist.selectedPlaylist === '') {
+        dispatch(setSelectedPlaylist(items[0].id)); // set first playlist as selected
+      }
     };
     getPlaylistData();
-  }, [dispatch]);
+  }, [dispatch, playlist.selectedPlaylist]);
 
   return (
     <PlaylistContainer>

--- a/client/src/components/Playlist/Playlist.tsx
+++ b/client/src/components/Playlist/Playlist.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useAppDispatch } from 'src/store/hooks';
+import usePlaylist from 'src/utils/usePlaylist';
+import { setPlaylist } from '../../store/musicPlayerSlice';
+import { PlaylistContainer } from '../../styles/PlaylistStyle';
+import { PlaylistItemsType } from '../../types';
+
+function Playlist() {
+  const dispatch = useAppDispatch();
+  const playlist = usePlaylist();
+
+  useEffect(() => {
+    const getPlaylistData = async () => {
+      const response = await fetch('/auth/me/playlist');
+      const data = await response.json();
+      const { items } = JSON.parse(data);
+      const playlists = items.map(
+        ({ name, id }: PlaylistItemsType) => {
+          return { name, id };
+        },
+      );
+      dispatch(setPlaylist(playlists));
+    };
+    getPlaylistData();
+  }, [dispatch]);
+
+  return (
+    <PlaylistContainer>
+      <ul>
+        {playlist.playlist.map(({ name, id }) => {
+          return <li key={id}>{name}</li>;
+        })}
+      </ul>
+    </PlaylistContainer>
+  );
+}
+
+export default Playlist;

--- a/client/src/components/Search/Search.test.tsx
+++ b/client/src/components/Search/Search.test.tsx
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import Search from './Search';
-
-test('allow user to authenticate', async () => {
-  render(<Search />);
-  const linkElement = screen.getByText(/Login with Spotify/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/client/src/components/Search/Search.tsx
+++ b/client/src/components/Search/Search.tsx
@@ -1,5 +1,0 @@
-function Search() {
-  return <p>meow--search</p>;
-}
-
-export default Search;

--- a/client/src/components/Sidebar/Sidebar.test.tsx
+++ b/client/src/components/Sidebar/Sidebar.test.tsx
@@ -1,8 +1,18 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { store } from '../../store';
 import Sidebar from './Sidebar';
 
-test('allow user to authenticate', async () => {
-  render(<Sidebar />);
-  const linkElement = screen.getByText(/Login with Spotify/i);
-  expect(linkElement).toBeInTheDocument();
+test('test if side bar list items are on the screen', async () => {
+  render(
+    <Provider store={store}>
+      <Sidebar />
+    </Provider>,
+  );
+  const homeElement = screen.getByText(/home/i);
+  const libraryElement = screen.getByText(/your library/i);
+  const searchElement = screen.getByText(/search/i);
+  expect(homeElement).toBeInTheDocument();
+  expect(libraryElement).toBeInTheDocument();
+  expect(searchElement).toBeInTheDocument();
 });

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -1,9 +1,38 @@
-import { SidebarContainer } from '../../styles/SidebarStyle';
+import { IoLibrary } from 'react-icons/io5';
+import { MdHomeFilled, MdSearch } from 'react-icons/md';
+import {
+  SidebarContainer,
+  LinkWrapper,
+  LogoWrapper,
+} from '../../styles/SidebarStyle';
+import Playlist from '../Playlist/Playlist';
 
 function Sidebar() {
   return (
     <SidebarContainer>
-      <p>sidebar--meow</p>
+      <LinkWrapper>
+        <LogoWrapper>
+          <img
+            src="https://storage.googleapis.com/pr-newsroom-wp/1/2018/11/Spotify_Logo_CMYK_White.png"
+            alt="spotify logo"
+          />
+        </LogoWrapper>
+        <ul>
+          <li>
+            <MdHomeFilled />
+            <span>Home</span>
+          </li>
+          <li>
+            <MdSearch />
+            <span>Search</span>
+          </li>
+          <li>
+            <IoLibrary />
+            <span>Your Library</span>
+          </li>
+        </ul>
+      </LinkWrapper>
+      <Playlist />
     </SidebarContainer>
   );
 }

--- a/client/src/components/SpotifyContent/SpotifyContent.test.tsx
+++ b/client/src/components/SpotifyContent/SpotifyContent.test.tsx
@@ -6,9 +6,9 @@ import SpotifyContent from './SpotifyContent';
 test('allow user to authenticate', async () => {
   render(
     <Provider store={store}>
-      <SpotifyContent />
+      <SpotifyContent headerBackground={false} />
     </Provider>,
   );
-  const linkElement = screen.getByText(/meow/i);
+  const linkElement = screen.getByText(/playlist/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/client/src/components/SpotifyContent/SpotifyContent.test.tsx
+++ b/client/src/components/SpotifyContent/SpotifyContent.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { store } from '../../store';
 import SpotifyContent from './SpotifyContent';
 
 test('allow user to authenticate', async () => {
-  render(<SpotifyContent />);
-  const linkElement = screen.getByText(/Login with Spotify/i);
+  render(
+    <Provider store={store}>
+      <SpotifyContent />
+    </Provider>,
+  );
+  const linkElement = screen.getByText(/meow/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/client/src/components/SpotifyContent/SpotifyContent.tsx
+++ b/client/src/components/SpotifyContent/SpotifyContent.tsx
@@ -3,10 +3,25 @@ import { AiFillClockCircle } from 'react-icons/ai';
 import { useAppDispatch } from 'src/store/hooks';
 import { setPlaylistSongs } from 'src/store/musicPlayerSlice';
 import usePlaylist from 'src/utils/usePlaylist';
-import { ContentContainer } from '../../styles/SpotifyContent';
-import { TrackType, ArtistProp } from '../../types';
+import {
+  ContentContainer,
+  ListInfoWrapper,
+  ImageWrapper,
+  DetailWrapper,
+  HeaderRow,
+  HeaderCol,
+  SongListContainer,
+  SongWrapper,
+  SongRow,
+  SongCol,
+  SongColDetail,
+  SongImageWrapper,
+  SongInfoWrapper,
+} from '../../styles/SpotifyContent';
+import { TrackType, ArtistProp, HeaderBkgdType } from '../../types';
+import { convertMsToStandardTime } from '../../utils/Functions';
 
-function SpotifyContent() {
+function SpotifyContent({ headerBackground }: HeaderBkgdType) {
   const dispatch = useAppDispatch();
   const playlist = usePlaylist();
 
@@ -46,10 +61,92 @@ function SpotifyContent() {
     }
   }, [dispatch, playlist.selectedPlaylist]);
 
+  useEffect(() => {
+    if (playlist.playlistSongs) {
+      console.log(playlist.playlistSongs.tracks);
+    }
+  });
+
   return (
     <ContentContainer>
-      <AiFillClockCircle />
-      <p>meow</p>
+      {playlist.playlistSongs && (
+        <>
+          <ListInfoWrapper>
+            <ImageWrapper>
+              <img
+                src={playlist.playlistSongs.image}
+                alt="playlist album cover"
+              />
+            </ImageWrapper>
+            <DetailWrapper>
+              <span>PLAYLIST</span>
+              <h1>{playlist.playlistSongs.name}</h1>
+              <p>{playlist.playlistSongs.description}</p>
+            </DetailWrapper>
+          </ListInfoWrapper>
+          <SongListContainer>
+            <HeaderRow headerBackground={headerBackground}>
+              <HeaderCol>
+                <span>#</span>
+              </HeaderCol>
+              <HeaderCol>
+                <span>TITLE</span>
+              </HeaderCol>
+              <HeaderCol>
+                <span>ALBUM</span>
+              </HeaderCol>
+              <HeaderCol>
+                <span>
+                  <AiFillClockCircle />
+                </span>
+              </HeaderCol>
+            </HeaderRow>
+            <SongWrapper>
+              {playlist.playlistSongs.tracks &&
+                playlist.playlistSongs.tracks.map(
+                  (
+                    {
+                      id,
+                      image,
+                      name,
+                      artists,
+                      album,
+                      duration,
+                      // context_uri,
+                      // track_number,
+                    },
+                    i,
+                  ) => {
+                    return (
+                      <SongRow key={id}>
+                        <SongCol>
+                          <span>{i + 1}</span>
+                        </SongCol>
+                        <SongColDetail>
+                          <SongImageWrapper>
+                            <img src={image} alt="track album art" />
+                          </SongImageWrapper>
+                          <SongInfoWrapper>
+                            <span>{name}</span>
+                            <span>{artists.join(', ')}</span>
+                          </SongInfoWrapper>
+                        </SongColDetail>
+                        <SongCol>
+                          <span>{album}</span>
+                        </SongCol>
+                        <SongCol>
+                          <span>
+                            {convertMsToStandardTime(duration)}
+                          </span>
+                        </SongCol>
+                      </SongRow>
+                    );
+                  },
+                )}
+            </SongWrapper>
+          </SongListContainer>
+        </>
+      )}
     </ContentContainer>
   );
 }

--- a/client/src/components/SpotifyContent/SpotifyContent.tsx
+++ b/client/src/components/SpotifyContent/SpotifyContent.tsx
@@ -1,7 +1,51 @@
+import { useEffect } from 'react';
 import { AiFillClockCircle } from 'react-icons/ai';
+import { useAppDispatch } from 'src/store/hooks';
+import { setPlaylistSongs } from 'src/store/musicPlayerSlice';
+import usePlaylist from 'src/utils/usePlaylist';
 import { ContentContainer } from '../../styles/SpotifyContent';
+import { TrackType, ArtistProp } from '../../types';
 
 function SpotifyContent() {
+  const dispatch = useAppDispatch();
+  const playlist = usePlaylist();
+
+  useEffect(() => {
+    const getPlaylistSongs = async () => {
+      const response = await fetch(
+        `/auth/playlists/${playlist.selectedPlaylist}`,
+      );
+      const resData = await response.json();
+      const data = JSON.parse(resData);
+      const songData = {
+        id: data.id,
+        name: data.name,
+        description: data.description.startsWith('<a')
+          ? ''
+          : data.description,
+        image: data.images[0].url,
+        tracks: data.tracks.items.map(({ track }: TrackType) => ({
+          id: track.id,
+          name: track.name,
+          artists: track.artists.map(
+            (artist: ArtistProp) => artist.name,
+          ),
+          image: track.album.images[2].url,
+          duration: track.duration_ms,
+          album: track.album.name,
+          context_uri: track.album.uri,
+          track_number: track.track_number,
+        })),
+      };
+      if (songData) {
+        dispatch(setPlaylistSongs(songData)); // set song data from selected playlist
+      }
+    };
+    if (playlist.selectedPlaylist) {
+      getPlaylistSongs();
+    }
+  }, [dispatch, playlist.selectedPlaylist]);
+
   return (
     <ContentContainer>
       <AiFillClockCircle />

--- a/client/src/components/SpotifyContent/SpotifyContent.tsx
+++ b/client/src/components/SpotifyContent/SpotifyContent.tsx
@@ -1,5 +1,13 @@
+import { AiFillClockCircle } from 'react-icons/ai';
+import { ContentContainer } from '../../styles/SpotifyContent';
+
 function SpotifyContent() {
-  return <p>spoopifycontent--meow</p>;
+  return (
+    <ContentContainer>
+      <AiFillClockCircle />
+      <p>meow</p>
+    </ContentContainer>
+  );
 }
 
 export default SpotifyContent;

--- a/client/src/components/SpotifyTheme/SpotifyTheme.test.tsx
+++ b/client/src/components/SpotifyTheme/SpotifyTheme.test.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { store } from '../../store';
 import SpotifyTheme from './SpotifyTheme';
 
-test('allow user to authenticate', async () => {
-  render(<SpotifyTheme />);
-  const linkElement = screen.getByText(/Login with Spotify/i);
+test('check if search component loads', async () => {
+  render(
+    <Provider store={store}>
+      <SpotifyTheme />
+    </Provider>,
+  );
+  const linkElement = screen.getByPlaceholderText(
+    /what do you want to listen to/i,
+  );
   expect(linkElement).toBeInTheDocument();
 });

--- a/client/src/components/SpotifyTheme/SpotifyTheme.tsx
+++ b/client/src/components/SpotifyTheme/SpotifyTheme.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef } from 'react';
 import {
   SpotifyThemeContainer,
   SidebarWrapper,
@@ -9,14 +10,30 @@ import NavBar from '../NavBar/NavBar';
 import SpotifyContent from '../SpotifyContent/SpotifyContent';
 
 function SpotifyTheme() {
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const [navBackground, setNavBackground] = useState<boolean>(false);
+  const [headerBackground, setHeaderBackground] =
+    useState<boolean>(false);
+
+  const bodyScrolled = () => {
+    if (bodyRef.current !== null) {
+      bodyRef.current.scrollTop >= 30
+        ? setNavBackground(true)
+        : setNavBackground(false);
+      bodyRef.current.scrollTop >= 268
+        ? setHeaderBackground(true)
+        : setHeaderBackground(false);
+    }
+  };
+
   return (
     <SpotifyThemeContainer>
       <SidebarWrapper>
         <Sidebar />
-        <NavBarWrapper>
-          <NavBar />
+        <NavBarWrapper ref={bodyRef} onScroll={bodyScrolled}>
+          <NavBar navBackground={navBackground} />
           <ContentWrapper>
-            <SpotifyContent />
+            <SpotifyContent headerBackground={headerBackground} />
           </ContentWrapper>
         </NavBarWrapper>
       </SidebarWrapper>

--- a/client/src/components/SpotifyTheme/SpotifyTheme.tsx
+++ b/client/src/components/SpotifyTheme/SpotifyTheme.tsx
@@ -1,11 +1,11 @@
 import {
   SpotifyThemeContainer,
   SidebarWrapper,
-  SearchWrapper,
+  NavBarWrapper,
   ContentWrapper,
 } from '../../styles/SpotifyThemeStyle';
 import Sidebar from '../Sidebar/Sidebar';
-import Search from '../Search/Search';
+import NavBar from '../NavBar/NavBar';
 import SpotifyContent from '../SpotifyContent/SpotifyContent';
 
 function SpotifyTheme() {
@@ -13,12 +13,12 @@ function SpotifyTheme() {
     <SpotifyThemeContainer>
       <SidebarWrapper>
         <Sidebar />
-        <SearchWrapper>
-          <Search />
+        <NavBarWrapper>
+          <NavBar />
           <ContentWrapper>
             <SpotifyContent />
           </ContentWrapper>
-        </SearchWrapper>
+        </NavBarWrapper>
       </SidebarWrapper>
     </SpotifyThemeContainer>
   );

--- a/client/src/components/WebPlayback/WebPlayback.test.tsx
+++ b/client/src/components/WebPlayback/WebPlayback.test.tsx
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import WebPlayback from './WebPlayback';
-
-test('allow user to authenticate', () => {
-  render(<WebPlayback />);
-  const linkElement = screen.getByText(/Instance not active./i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,13 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import tokenReducer from './tokenSlice';
-// import musicPlayerReducer from './musicPlayerSlice';
-// import userReducer from './userSlice';
+import musicPlayerReducer from './musicPlayerSlice';
+import userReducer from './userSlice';
 
 export const store = configureStore({
   reducer: {
     token: tokenReducer,
-    // musicPlayer: musicPlayerReducer,
-    // user: userReducer,
+    musicPlayer: musicPlayerReducer,
+    user: userReducer,
   },
 });
 

--- a/client/src/store/musicPlayerSlice.ts
+++ b/client/src/store/musicPlayerSlice.ts
@@ -1,21 +1,30 @@
 import { createSlice } from '@reduxjs/toolkit';
-import type { RootState } from './index';
+// import type { RootState } from './index';
 
-type ExampleTypes = {
-  mewo: boolean;
+type PlaylistProps = {
+  name: string;
+  id: string;
+};
+
+type MusicPlayerTypes = {
+  playlist: PlaylistProps[];
 };
 
 const initialState = {
-  mewo: true,
-} as ExampleTypes;
+  playlist: [],
+} as MusicPlayerTypes;
 
 export const musicPlayerSlice = createSlice({
   name: 'musicPlayer',
   initialState,
-  reducers: {},
+  reducers: {
+    setPlaylist(state, { payload }) {
+      state.playlist = payload;
+    },
+  },
 });
 
-export const musicPlayerState = (state: RootState) => state;
-// export const {} = musicPlayerSlice.actions; PLACEHOLDER
+// export const musicPlayerState = (state: RootState) => state;
+export const { setPlaylist } = musicPlayerSlice.actions;
 
 export default musicPlayerSlice.reducer;

--- a/client/src/store/musicPlayerSlice.ts
+++ b/client/src/store/musicPlayerSlice.ts
@@ -1,22 +1,40 @@
 import { createSlice } from '@reduxjs/toolkit';
-// import type { RootState } from './index';
 
 type PlaylistProps = {
   name: string;
   id: string;
 };
 
+type PlaylistSongProps = {
+  id: string;
+  name: string;
+  description: string;
+  image: string;
+  tracks: OutputTrackProps[];
+};
+
+type OutputTrackProps = {
+  album: string;
+  artists: string[];
+  context_uri: string;
+  duration: number;
+  id: string;
+  image: string;
+  name: string;
+  track_number: number;
+};
+
 type MusicPlayerTypes = {
   playlist: PlaylistProps[];
   selectedPlaylist: string;
-  playlistSongs: {};
+  playlistSongs: PlaylistSongProps;
 };
 
 const initialState = {
   playlist: [],
   selectedPlaylist: '',
   playlistSongs: {},
-} as MusicPlayerTypes;
+} as unknown as MusicPlayerTypes;
 
 export const musicPlayerSlice = createSlice({
   name: 'musicPlayer',

--- a/client/src/store/musicPlayerSlice.ts
+++ b/client/src/store/musicPlayerSlice.ts
@@ -8,10 +8,14 @@ type PlaylistProps = {
 
 type MusicPlayerTypes = {
   playlist: PlaylistProps[];
+  selectedPlaylist: string;
+  playlistSongs: {};
 };
 
 const initialState = {
   playlist: [],
+  selectedPlaylist: '',
+  playlistSongs: {},
 } as MusicPlayerTypes;
 
 export const musicPlayerSlice = createSlice({
@@ -21,10 +25,17 @@ export const musicPlayerSlice = createSlice({
     setPlaylist(state, { payload }) {
       state.playlist = payload;
     },
+    setSelectedPlaylist(state, { payload }) {
+      state.selectedPlaylist = payload;
+    },
+    setPlaylistSongs(state, { payload }) {
+      state.playlistSongs = payload;
+    },
   },
 });
 
 // export const musicPlayerState = (state: RootState) => state;
-export const { setPlaylist } = musicPlayerSlice.actions;
+export const { setPlaylist, setSelectedPlaylist, setPlaylistSongs } =
+  musicPlayerSlice.actions;
 
 export default musicPlayerSlice.reducer;

--- a/client/src/store/userSlice.ts
+++ b/client/src/store/userSlice.ts
@@ -1,21 +1,30 @@
 import { createSlice } from '@reduxjs/toolkit';
-import type { RootState } from './index';
+// import type { RootState } from './index';
 
-type ExampleTypes = {
-  mewo: boolean;
+type UserProps = {
+  userId: string;
+  userName: string;
+};
+
+type UserTypes = {
+  userInfo: UserProps;
 };
 
 const initialState = {
-  mewo: true,
-} as ExampleTypes;
+  userInfo: {},
+} as UserTypes;
 
 export const userSlice = createSlice({
-  name: 'example',
+  name: 'user',
   initialState,
-  reducers: {},
+  reducers: {
+    setUserInfo(state, { payload }) {
+      state.userInfo = payload;
+    },
+  },
 });
 
-export const userState = (state: RootState) => state;
-// export const {} = userSlice.actions; PLACEHOLDER
+// export const userState = (state: RootState) => state;
+export const { setUserInfo } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/client/src/styles/NavBarStyle.ts
+++ b/client/src/styles/NavBarStyle.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
+import { NavBkgdType } from '../types';
 
-export const NavContainer = styled.section`
+export const NavContainer = styled.section<NavBkgdType>`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -9,7 +10,8 @@ export const NavContainer = styled.section`
   position: sticky;
   top: 0;
   transition: 0.3s ease-in-out;
-  background-color: none;
+  background-color: ${({ navBackground }) =>
+    navBackground ? 'rgba(0, 0, 0, 0.7)' : 'none'};
 `;
 
 export const SearchWrapper = styled.div`

--- a/client/src/styles/NavBarStyle.ts
+++ b/client/src/styles/NavBarStyle.ts
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+export const NavContainer = styled.section`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2rem;
+  height: 15vh;
+  position: sticky;
+  top: 0;
+  transition: 0.3s ease-in-out;
+  background-color: none;
+`;
+
+export const SearchWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  background-color: #ffffff;
+  width: 30%;
+  padding: 0.4rem 1rem;
+  border-radius: 2rem;
+  gap: 0.5rem;
+  input {
+    border: none;
+    height: 2rem;
+    width: 100%;
+    &:focus {
+      outline: none;
+    }
+  }
+`;
+
+export const UserWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #000000;
+  padding: 0.3rem 0.4rem;
+  padding-right: 1rem;
+  border-radius: 2rem;
+  a {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    color: #ffffff;
+    font-weight: bold;
+    svg {
+      font-size: 1.3rem;
+      background-color: #282828;
+      padding: 0.2rem;
+      border-radius: 1rem;
+      color: #c7c5c5;
+    }
+  }
+`;

--- a/client/src/styles/PlaylistStyle.ts
+++ b/client/src/styles/PlaylistStyle.ts
@@ -18,6 +18,7 @@ export const PlaylistContainer = styled.div`
         background-color: rgba(255, 255, 255, 0.6);
       }
     }
+    scrollbar-width: thin;
     li {
       display: flex;
       gap: 1rem;

--- a/client/src/styles/PlaylistStyle.ts
+++ b/client/src/styles/PlaylistStyle.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const PlaylistContainer = styled.div`
+  height: 100%;
+  overflow: hidden;
+  ul {
+    list-style-type: none;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+    height: 52vh;
+    max-height: 100%;
+    overflow: auto;
+    &::-webkit-scrollbar {
+      width: 0.7rem;
+      &-thumb {
+        background-color: rgba(255, 255, 255, 0.6);
+      }
+    }
+    li {
+      display: flex;
+      gap: 1rem;
+      cursor: pointer;
+      transition: 0.3s ease-in-out;
+      &:hover {
+        color: #ffffff;
+      }
+    }
+  }
+`;

--- a/client/src/styles/SidebarStyle.ts
+++ b/client/src/styles/SidebarStyle.ts
@@ -2,4 +2,39 @@ import styled from 'styled-components';
 
 export const SidebarContainer = styled.div`
   background-color: #000000;
+  color: #b3b3b3;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+`;
+
+export const LinkWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  ul {
+    display: flex;
+    flex-direction: column;
+    list-style-type: none;
+    gap: 1rem;
+    padding: 1rem;
+    li {
+      display: flex;
+      gap: 1rem;
+      cursor: pointer;
+      transition: 0.3s ease-in-out;
+      &:hover {
+        color: #ffffff;
+      }
+    }
+  }
+`;
+
+export const LogoWrapper = styled.div`
+  text-align: center;
+  margin: 1rem 0;
+  img {
+    max-inline-size: 80%;
+    block-size: auto;
+  }
 `;

--- a/client/src/styles/SpotifyContent.ts
+++ b/client/src/styles/SpotifyContent.ts
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const ContentContainer = styled.section``;

--- a/client/src/styles/SpotifyContent.ts
+++ b/client/src/styles/SpotifyContent.ts
@@ -1,3 +1,79 @@
 import styled from 'styled-components';
+import { HeaderBkgdType } from 'src/types';
 
 export const ContentContainer = styled.section``;
+export const ListInfoWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  margin: 0 2rem;
+`;
+export const ImageWrapper = styled.div`
+  img {
+    height: 15rem;
+    box-shadow: rgba(0, 0, 0, 0.25) 0px 25px 50px -12px;
+  }
+`;
+export const DetailWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: #e0dede;
+  h1 {
+    color: #ffffff;
+    font-size: 4rem;
+  }
+`;
+export const SongListContainer = styled.div``;
+export const HeaderRow = styled.div<HeaderBkgdType>`
+  display: grid;
+  grid-template-columns: 0.3fr 3fr 2fr 0.1fr;
+  color: #dddcdc;
+  margin: 1rem 0 0 0;
+  position: sticky;
+  top: 15vh;
+  padding: 1rem 3rem;
+  transition: 0.3s ease-in-out;
+  background-color: ${({ headerBackground }) =>
+    headerBackground ? '#000000dc' : 'none'};
+`;
+export const HeaderCol = styled.div`
+  display: flex;
+  align-items: center;
+  color: #dddcdc;
+`;
+export const SongWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 0 2rem;
+  margin-bottom: 5rem;
+`;
+export const SongRow = styled.div`
+  display: grid;
+  grid-template-columns: 0.3fr 3fr 2fr 0.1fr;
+  padding: 0.5rem 1rem;
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.7);
+  }
+`;
+export const SongCol = styled.div`
+  display: flex;
+  align-items: center;
+  color: #dddcdc;
+`;
+export const SongColDetail = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: #dddcdc;
+`;
+export const SongImageWrapper = styled.div`
+  img {
+    height: 40px;
+    width: 40px;
+  }
+`;
+export const SongInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/client/src/styles/SpotifyThemeStyle.ts
+++ b/client/src/styles/SpotifyThemeStyle.ts
@@ -19,5 +19,12 @@ export const NavBarWrapper = styled.div`
   height: 100%;
   width: 100%;
   overflow: auto;
+  &::-webkit-scrollbar {
+    width: 0.7rem;
+    &-thumb {
+      background-color: rgba(255, 255, 255, 0.6);
+    }
+  }
+  scrollbar-width: thin;
 `;
 export const ContentWrapper = styled.div``;

--- a/client/src/styles/SpotifyThemeStyle.ts
+++ b/client/src/styles/SpotifyThemeStyle.ts
@@ -15,7 +15,7 @@ export const SidebarWrapper = styled.div`
   background: linear-gradient(transparent, rgba(0, 0, 0, 1));
   background-color: rgb(32, 87, 100);
 `;
-export const SearchWrapper = styled.div`
+export const NavBarWrapper = styled.div`
   height: 100%;
   width: 100%;
   overflow: auto;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -14,8 +14,13 @@ export type PlaylistItemsType = {
   id: string;
 };
 
+// type for NavBar
+export type NavBkgdType = {
+  navBackground: boolean;
+};
+
 // types for spotify content
-export type TrackProps = {
+type TrackProps = {
   id: string;
   name: string;
   artists: ArtistProp[];
@@ -26,20 +31,24 @@ export type TrackProps = {
   track_number: number;
 };
 
-export type TrackType = {
-  track: TrackProps;
-};
-
-export type AlbumProps = {
+type AlbumProps = {
   images: ImagesProp[];
   name: string;
   uri: string;
 };
 
-export type ImagesProp = {
+type ImagesProp = {
   url: string;
+};
+
+export type TrackType = {
+  track: TrackProps;
 };
 
 export type ArtistProp = {
   name: string;
+};
+
+export type HeaderBkgdType = {
+  headerBackground: boolean;
 };

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -5,3 +5,8 @@ export type PlaybackType = {
 export type ListenerEventType = {
   device_id: string;
 };
+
+export type PlaylistItemsType = {
+  name: string;
+  id: string;
+};

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,12 +1,45 @@
+// type for app
 export type PlaybackType = {
   token: string;
 };
 
+// type for webplayer
 export type ListenerEventType = {
   device_id: string;
 };
 
+// type for playlist
 export type PlaylistItemsType = {
   name: string;
   id: string;
+};
+
+// types for spotify content
+export type TrackProps = {
+  id: string;
+  name: string;
+  artists: ArtistProp[];
+  image: string;
+  duration_ms: number;
+  album: AlbumProps;
+  context_uri: string;
+  track_number: number;
+};
+
+export type TrackType = {
+  track: TrackProps;
+};
+
+export type AlbumProps = {
+  images: ImagesProp[];
+  name: string;
+  uri: string;
+};
+
+export type ImagesProp = {
+  url: string;
+};
+
+export type ArtistProp = {
+  name: string;
 };

--- a/client/src/utils/Functions.ts
+++ b/client/src/utils/Functions.ts
@@ -1,0 +1,6 @@
+export const convertMsToStandardTime = (ms: number) => {
+  const minutes = Math.floor(ms / 60000);
+  const seconds = ((ms % 60000) / 1000).toFixed(0);
+  const addZeroMaybe = Number(seconds) < 10 ? '0' : '';
+  return `${minutes}:${addZeroMaybe}${seconds}`;
+};

--- a/client/src/utils/usePlaylist.tsx
+++ b/client/src/utils/usePlaylist.tsx
@@ -1,0 +1,8 @@
+import { shallowEqual } from 'react-redux';
+import { useAppSelector } from 'src/store/hooks';
+
+function usePlaylist() {
+  return useAppSelector((state) => state.musicPlayer, shallowEqual);
+}
+
+export default usePlaylist;

--- a/client/src/utils/useUserInfo.tsx
+++ b/client/src/utils/useUserInfo.tsx
@@ -1,0 +1,8 @@
+import { shallowEqual } from 'react-redux';
+import { useAppSelector } from 'src/store/hooks';
+
+function useUserInfo() {
+  return useAppSelector((state) => state.user, shallowEqual);
+}
+
+export default useUserInfo;

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,10 +21,12 @@ const spotifyClientId = process.env.SPOTIFY_CLIENT_ID;
 const spotifyClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
 const spotifyRedirectUri = process.env.SPOTIFY_REDIRECT_URI;
 
+// mostly for redirecting
 app.get('/', (_req, res) => {
   res.send('redirecting...');
 });
 
+// login endpoint
 app.get('/auth/login', (_req, res) => {
   // const scope =
   //   'streaming user-read-email user-read-private user-modify-playback-state user-read-playback-state user-read-currently-playing user-read-recently-played user-read-playback-position user-top-read';
@@ -53,6 +55,7 @@ app.get('/auth/login', (_req, res) => {
   );
 });
 
+// callback endpoint
 app.get('/auth/callback', (req, res) => {
   const { code } = req.query;
 
@@ -82,13 +85,62 @@ app.get('/auth/callback', (req, res) => {
         response.body.error,
         response.body.error.error_description,
       );
-      res.end();
+      res.end(response.body);
     }
   });
 });
 
+// token endpoint
 app.get('/auth/token', (_req, res) => {
   res.json({ access_token: accessToken });
+});
+
+// userInfo endpoint
+app.get('/auth/me', (_req, res) => {
+  const authMeOptions = {
+    url: 'https://api.spotify.com/v1/me',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  request.get(authMeOptions, function (error, response, body) {
+    if (!error && response.statusCode === 200) {
+      res.json(response.body);
+    } else {
+      console.log(
+        error,
+        response.body.error,
+        response.body.error.error_description,
+      );
+      res.end(body);
+    }
+  });
+});
+
+// playlist endpoint
+app.get('/auth/me/playlist', (_req, res) => {
+  const authPlaylistOptions = {
+    url: 'https://api.spotify.com/v1/me/playlists',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  request.get(authPlaylistOptions, function (error, response, body) {
+    if (!error && response.statusCode === 200) {
+      res.json(response.body);
+    } else {
+      console.log(
+        error,
+        response.body.error,
+        response.body.error.error_description,
+      );
+      res.end(body);
+    }
+  });
 });
 
 app.listen(PORT, () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,8 +28,6 @@ app.get('/', (_req, res) => {
 
 // login endpoint
 app.get('/auth/login', (_req, res) => {
-  // const scope =
-  //   'streaming user-read-email user-read-private user-modify-playback-state user-read-playback-state user-read-currently-playing user-read-recently-played user-read-playback-position user-top-read';
   const scope = [
     'streaming',
     'user-read-email',
@@ -40,6 +38,7 @@ app.get('/auth/login', (_req, res) => {
     'user-read-recently-played',
     'user-read-playback-position',
     'user-top-read',
+    'playlist-read-private',
   ];
   const state = generateRandomString(16);
   const authQueryParameters = new URLSearchParams({
@@ -123,6 +122,32 @@ app.get('/auth/me', (_req, res) => {
 app.get('/auth/me/playlist', (_req, res) => {
   const authPlaylistOptions = {
     url: 'https://api.spotify.com/v1/me/playlists',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  request.get(authPlaylistOptions, function (error, response, body) {
+    if (!error && response.statusCode === 200) {
+      res.json(response.body);
+    } else {
+      console.log(
+        error,
+        response.body.error,
+        response.body.error.error_description,
+      );
+      res.end(body);
+    }
+  });
+});
+
+// get playlist song data
+app.get('/auth/playlists/:playlist_id', (req, res) => {
+  const playlistId = req.params.playlist_id;
+  console.log(playlistId);
+  const authPlaylistOptions = {
+    url: `https://api.spotify.com/v1/playlists/${playlistId}`,
     headers: {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Changes
1. Add routes to user and playlist data
2. Add code for Spotify Theme, Spotify Content, Sidebar, Navbar, and Playlist components
3. Add styled component files for each component.
4. Move types from components to global type file. Mostly the types in the redux slices are not migrated yet because I'm not sure if the slices are completely finished yet.
5. Add one test for each component so far for TDD practices.

## Purpose
The purpose of the Spotify Theme component is to house the components for Spotify Content, Sidebar, Navbar, and Playlist. Spotify Content holds data for playlist songs and allows user to interact with songs. Sidebar allows user to interact with playlist. Playlist gets the initial playlist data. Navbar houses user info and music search.

## Approach
The initial tutorial found on the Spotify Developer page was definitely a good starting point, but I want to have a more fleshed out music player. Transition to a Spotify Clone is definitely a step in the right direction.

## Learning
Creating and developing a Spotify clones helps me understand how to interact with the Spotify API a lot more, especially when creating requests to the available endpoints. The goal is to eventually have three different themes where Spotify Theme is the learning phase, the second Discover Theme is the actual MVP, and Visualization Theme is an additional feature.

P.S - My bad this push was 800+ lines. I'm almost to the actual feature that this branch is suppose to be. A little disorganized, but it should improve after the music player control buttons are in.